### PR TITLE
Fix EBSBackupInfo.ClusterInfo panic nil pointer

### DIFF
--- a/br/pkg/backup/ebs.go
+++ b/br/pkg/backup/ebs.go
@@ -104,11 +104,19 @@ func (c *EBSBackupInfo) ConfigFromFile(path string) error {
 	return nil
 }
 
+func (c *EBSBackupInfo) CheckClusterInfo() {
+	if c.ClusterInfo == nil {
+		c.ClusterInfo = &ClusterInfo{}
+	}
+}
+
 func (c *EBSBackupInfo) SetClusterID(id uint64) {
+	c.CheckClusterInfo()
 	c.ClusterInfo.ID = id
 }
 
 func (c *EBSBackupInfo) SetAllocID(id uint64) {
+	c.CheckClusterInfo()
 	c.ClusterInfo.MaxAllocID = id
 }
 


### PR DESCRIPTION
the panic caused by the `volume-file` missing `cluster_info` field - logically it shouldn't exist

<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

Issue Number: close #xxx <!-- REMOVE this line if no issue to close -->

Problem Summary:

### What is changed and how it works?

Proposal: [xxx](url) <!-- REMOVE this line if not applicable -->

What's Changed:

How it Works:

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
Please add a release note, or a 'None' if it is not needed.
```
