### PR TITLE
compact_logs: make it work

### DIFF
--- a/br/pkg/restore/snap_client/sstfiles/import.go
+++ b/br/pkg/restore/snap_client/sstfiles/import.go
@@ -368,6 +368,7 @@ func (importer *SnapFileImporter) ImportSSTFiles(
 							logutil.Key("endKey", endKey),
 							logutil.Key("file-simple-start", files[0].StartKey),
 							logutil.Key("file-simple-end", files[0].EndKey),
+							zap.Stringer("rewrite-rules", rewriteRules),
 							logutil.ShortError(e))
 						continue regionLoop
 					}

--- a/br/pkg/restore/snap_client/sstfiles/multi_tables_restorer.go
+++ b/br/pkg/restore/snap_client/sstfiles/multi_tables_restorer.go
@@ -24,9 +24,9 @@ import (
 	"time"
 
 	"github.com/juju/errors"
-	"github.com/ngaut/log"
 	"github.com/opentracing/opentracing-go"
 	backuppb "github.com/pingcap/kvproto/pkg/brpb"
+	"github.com/pingcap/log"
 	"github.com/pingcap/tidb/br/pkg/checkpoint"
 	"github.com/pingcap/tidb/br/pkg/glue"
 	"github.com/pingcap/tidb/br/pkg/logutil"

--- a/br/pkg/restore/snap_client/sstfiles/simple_restorer.go
+++ b/br/pkg/restore/snap_client/sstfiles/simple_restorer.go
@@ -21,7 +21,7 @@ import (
 	"context"
 
 	"github.com/juju/errors"
-	"github.com/ngaut/log"
+	"github.com/pingcap/log"
 	"github.com/pingcap/tidb/br/pkg/glue"
 	"github.com/pingcap/tidb/br/pkg/logutil"
 	"github.com/pingcap/tidb/br/pkg/restore/internal/utils"
@@ -57,15 +57,14 @@ func (s *SimpleFileRestorer) Close() error {
 // data range after rewrite.
 // updateCh is used to record progress.
 func (s *SimpleFileRestorer) SplitRanges(ctx context.Context, ranges []rtree.Range, updateCh glue.Progress) error {
-	var splitClientOpt split.ClientOptionalParameter
 	if updateCh != nil {
-		splitClientOpt = split.WithOnSplit(func(keys [][]byte) {
+		splitClientOpt := split.WithOnSplit(func(keys [][]byte) {
 			for range keys {
 				updateCh.Inc()
 			}
 		})
+		s.splitter.ApplyOptions(splitClientOpt)
 	}
-	s.splitter.ApplyOptions(splitClientOpt)
 	splitter := utils.NewRegionSplitter(s.splitter)
 	return splitter.ExecuteSplit(ctx, ranges)
 }

--- a/br/pkg/restore/utils/rewrite_rule.go
+++ b/br/pkg/restore/utils/rewrite_rule.go
@@ -16,6 +16,7 @@ package utils
 
 import (
 	"bytes"
+	"strings"
 
 	"github.com/pingcap/errors"
 	backuppb "github.com/pingcap/kvproto/pkg/brpb"
@@ -278,6 +279,26 @@ func FindMatchedRewriteRule(file AppliedFile, rules *RewriteRules) *import_sstpb
 	return rule
 }
 
+func (rs *RewriteRules) String() string {
+	var out strings.Builder
+	out.WriteRune('[')
+	if len(rs.OldKeyspace) != 0 {
+		out.WriteString(redact.Key(rs.OldKeyspace))
+		out.WriteString(" =[ks]=> ")
+		out.WriteString(redact.Key(rs.NewKeyspace))
+	}
+	for i, d := range rs.Data {
+		if i > 0 {
+			out.WriteString(",")
+		}
+		out.WriteString(redact.Key(d.OldKeyPrefix))
+		out.WriteString(" => ")
+		out.WriteString(redact.Key(d.NewKeyPrefix))
+	}
+	out.WriteRune(']')
+	return out.String()
+}
+
 // GetRewriteRawKeys rewrites rules to the raw key.
 func GetRewriteRawKeys(file AppliedFile, rewriteRules *RewriteRules) (startKey, endKey []byte, err error) {
 	startID := tablecodec.DecodeTableID(file.GetStartKey())
@@ -286,7 +307,7 @@ func GetRewriteRawKeys(file AppliedFile, rewriteRules *RewriteRules) (startKey, 
 	if startID == endID {
 		startKey, rule = rewriteRawKey(file.GetStartKey(), rewriteRules)
 		if rewriteRules != nil && rule == nil {
-			err = errors.Annotatef(berrors.ErrRestoreInvalidRewrite, "cannot find raw rewrite rule for start key, startKey: %s", redact.Key(file.GetStartKey()))
+			err = errors.Annotatef(berrors.ErrRestoreInvalidRewrite, "cannot find raw rewrite rule for start key, startKey: %s; self = %s", redact.Key(file.GetStartKey()), rewriteRules)
 			return
 		}
 		endKey, rule = rewriteRawKey(file.GetEndKey(), rewriteRules)

--- a/br/pkg/storage/helper.go
+++ b/br/pkg/storage/helper.go
@@ -55,7 +55,7 @@ func UnmarshalDir[T any](ctx context.Context, walkOpt *WalkOption, s ExternalSto
 			}
 			var meta T
 			if err := unmarshal(&meta, path, metaBytes); err != nil {
-				return errors.Annotatef(err, "failed to parse subcompaction meta of file %s", path)
+				return errors.Annotatef(err, "failed to unmarshal file %s", path)
 			}
 			select {
 			case ch <- &meta:


### PR DESCRIPTION
This fixed some bugs that may cause panicking or data loss during restoring backup archive with SSTs. Including:
- Use right rewrite rule generation. (`Keyspaced`)
- Skip tables excluded (who doesn't have a rewrite rules)
- Unmarshal `Subcompactions` instead of `Subcompaction`.
- Enable import mode when not executed with full restoring.
- Initialize the `WithMigrations` earlier. (So won't panic when reading metas.)